### PR TITLE
Changes to wget parameters in run.sh to retry

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-wget -q -O /tftpboot/hanlon.ipxe ${HANLON_PORT/tcp/http}/hanlon/api/v1/config/ipxe
+wget --retry-connrefused --waitretry=5 --read-timeout=5 --timeout=5 -t 10 -q -O /tftpboot/hanlon.ipxe ${HANLON_PORT/tcp/http}/hanlon/api/v1/config/ipxe
+
+if [ $? -ne 0 ]
+then 
+  echo "Unable to download iPXE script from Hanlon container"
+  exit 1
+fi
+
 chmod -R 700 /tftpboot
 chown -R nobody:nogroup /tftpboot/
 /usr/sbin/atftpd --user nobody.nogroup --daemon --no-fork --port 69 --logfile /dev/stdout /tftpboot


### PR DESCRIPTION
In our Ansible automation we run a check before executing
the Hanlon container to determine if it is up and running before
launching the atftpd container.  This change will allow the removal
of that task and provide us the ability to use `docker-compose` in addition
to continuing to use Ansible docker automation.

Running docker-compose

```
root@ubuntu-hanlon:~# docker-compose up -d
Creating root_mongo_1
Creating root_server_1
Creating root_tftpd_1
```

Running containers

```
root@ubuntu-hanlon:~# docker ps -a
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                    NAMES
d02cdefeca3e        atftpd              "/bin/sh -c /run.sh"     About an hour ago   Up About an hour    0.0.0.0:69->69/udp       root_tftpd_1
3ee7473b402a        cscdock/hanlon      "/docker-entrypoint.s"   About an hour ago   Up About an hour    0.0.0.0:8026->8026/tcp   root_server_1
bab866bcded3        mongo               "/entrypoint.sh mongo"   About an hour ago   Up About an hour    27017/tcp                root_mongo_1
```

Enter the container confirm `hanlon.ipxe`

```
root@ubuntu-hanlon:~# docker exec -it d02 bash
root@d02cdefeca3e:/# cd tftpboot/
root@d02cdefeca3e:/tftpboot# tail hanlon.ipxe


:s1

chain http://10.53.252.89:8026/hanlon/api/v1/boot?uuid=${uuid}&mac_id=${net0/mac}_${net1/mac}_${net2/mac}_${net3/mac}_${net4/mac}_${net5/mac}_${net6/mac}_${net7/mac}&dhcp_mac=${dhcp_mac} || goto error


:error
sleep 15
reboot
```

Checking error handling 

```
root@ubuntu-hanlon:~# docker run -i atftpd
Unable to download iPXE script from Hanlon container
```
